### PR TITLE
Add random repair and damage options

### DIFF
--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/HolderClasses.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/HolderClasses.cs
@@ -9,5 +9,8 @@
         public bool LeftLegRepaired = false;
         public bool RightLegRepaired = false;
         public bool NoItems = true;
+        public bool RandomRepair = false;
+        public float RandomRepairChance = 0.5f;
+        public bool RandomDamageOnRepaired = true;
     }
 }

--- a/BrokenSalvagedMechs/BrokenSalvagedMechs/Patch.cs
+++ b/BrokenSalvagedMechs/BrokenSalvagedMechs/Patch.cs
@@ -23,29 +23,46 @@ namespace BrokenSalvagedMechs {
                         ReflectionHelper.InvokePrivateMethode(__instance, "RemoveItemStat", new object[] { id, "MECHPART", false });
                     }
                     MechDef mechDef = new MechDef(__instance.DataManager.MechDefs.Get(id), __instance.GenerateSimGameUID());
-                    if (!settings.HeadRepaired) {
+                    Random rng = new Random();
+                    if (!settings.HeadRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.Head.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.Head.CurrentInternalStructure = Math.Max(1f, mechDef.Head.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.LeftArmRepaired) {
+                    if (!settings.LeftArmRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.LeftArm.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.LeftArm.CurrentInternalStructure = Math.Max(1f, mechDef.LeftArm.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.RightArmRepaired) {
+                    if (!settings.RightArmRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.RightArm.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.RightArm.CurrentInternalStructure = Math.Max(1f, mechDef.RightArm.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.LeftLegRepaired) {
+                    if (!settings.LeftLegRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.LeftLeg.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.LeftLeg.CurrentInternalStructure = Math.Max(1f, mechDef.LeftLeg.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.RightLegRepaired) {
+                    if (!settings.RightLegRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.RightLeg.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.RightLeg.CurrentInternalStructure = Math.Max(1f, mechDef.RightLeg.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.CentralTorsoRepaired) {
+                    if (!settings.CentralTorsoRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.CenterTorso.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.CenterTorso.CurrentInternalStructure = Math.Max(1f, mechDef.CenterTorso.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.RightTorsoRepaired) {
+                    if (!settings.RightTorsoRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.RightTorso.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.RightTorso.CurrentInternalStructure = Math.Max(1f, mechDef.RightTorso.CurrentInternalStructure * (float)rng.NextDouble());
                     }
-                    if (!settings.LeftTorsoRepaired) {
+                    if (!settings.LeftTorsoRepaired && (!settings.RandomRepair || rng.NextDouble() > settings.RandomRepairChance)) {
                         mechDef.LeftTorso.CurrentInternalStructure = 0f;
+                    } else if (settings.RandomDamageOnRepaired) {
+                        mechDef.LeftTorso.CurrentInternalStructure = Math.Max(1f, mechDef.LeftTorso.CurrentInternalStructure * (float)rng.NextDouble());
                     }
                     foreach (MechComponentRef comp in mechDef.Inventory) {
                         if (mechDef.IsLocationDestroyed(comp.MountedLocation) || settings.NoItems) {

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ RightTorsoRepaired | bool | default false | Right torso will appear in mechbay a
 LeftLegRepaired | bool | default false | Left leg will appear in mechbay already repaired.
 RightLegRepaired | bool | default false | Right leg will appear in mechbay already repaired.
 NoItems | bool | default true | Items from the standard layout will be appear in mechbay destroyed, even when the part is set to beeing repaired.
+RandomRepair | bool | default false | Repair random parts in addition to repaired parts set above.
+RandomRepairChance | float | default 0.5 | Set value between 0 and 1 as a chance that parts will be repaired.
+RandomDamageOnRepaired | bool | default true | Repaired parts are not pristine condition. Instead they have random amount of damage to them.
     
 ## Install
 - After installing BTML, put  everything into \BATTLETECH\Mods\ folder.


### PR DESCRIPTION
Hi,
I'd like to improve options of having partial Mech salvage with your mod. Before your mod would allow some parts to be always repaired. It's always the same parts and they are always on full health.

With my changes it's possible to get random parts repaired with each salvaged Mech. This is in addition to any parts set to be always repaired in your original mod settings.

Also to help game immersion, there is an option to set random amount of damage on the repaired parts so the Mech salvage looks properly beaten up.

Here's an example of Mech salvage with both of the new options on:
http://svizel.kbx.cz/SalvageWithRandomOptions.jpg

By default, the RandomRepair option is off. So people would get exactly the same result with all parts broken as with your original default settings. RandomDamageOnRepaired is on by default, because the partially damaged parts just look so much better when people opt in to get some parts repaired.